### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     stats,
     Rcpp (>= 0.12.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     rstantools (>= 2.1.1),
     magrittr (>= 2.0),
     tibble,
@@ -47,8 +47,8 @@ LinkingTo:
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 SystemRequirements: GNU make
 Suggests: 
     rmarkdown,

--- a/inst/stan/Exponential_expert.stan
+++ b/inst/stan/Exponential_expert.stan
@@ -39,12 +39,12 @@ functions {
   }
 
 
-   real log_density_dist(real[ , ] params,
+   real log_density_dist(array[ , ] real params,
                         real x,int num_expert, int pool_type){
 
     // Evaluates the log density for a range of distributions
 
-    real dens[num_expert];
+    array[num_expert] real dens;
 
     for(i in 1:num_expert){
     if(params[i,1] == 1){
@@ -118,10 +118,10 @@ data {
   int id_trt;
   int id_comp;
 
-  int n_experts[n_time_expert];
+  array[n_time_expert] int n_experts;
   int pool_type;
 
-  real param_expert[max(n_experts),5,n_time_expert];
+  array[max(n_experts),5,n_time_expert] real param_expert;
   vector[St_indic ? n_time_expert : 0] time_expert;
 
 

--- a/inst/stan/RP_expert.stan
+++ b/inst/stan/RP_expert.stan
@@ -37,12 +37,12 @@ functions {
   }
 
 
-  real log_density_dist(real[ , ] params,
+  real log_density_dist(array[ , ] real params,
                         real x,int num_expert, int pool_type){
 
     // Evaluates the log density for a range of distributions
 
-    real dens[num_expert];
+    array[num_expert] real dens;
 
     for(i in 1:num_expert){
     if(params[i,1] == 1){
@@ -118,10 +118,10 @@ data {
   int id_trt;
   int id_comp;
 
-  int n_experts[n_time_expert];
+  array[n_time_expert] int n_experts;
   int pool_type;
 
-  real param_expert[max(n_experts),5,n_time_expert];
+  array[max(n_experts),5,n_time_expert] real param_expert;
   vector[St_indic ? n_time_expert : 0] time_expert;
 
   matrix[n_time_expert,M+2] B_expert;                  // matrix with basis for experts times

--- a/inst/stan/WeibullAF_expert.stan
+++ b/inst/stan/WeibullAF_expert.stan
@@ -62,11 +62,11 @@ functions {
 
 
      // Evaluates the log density for a range of distributions
-  real log_density_dist(real[ , ] params,
+  real log_density_dist(array[ , ] real params,
                         real x,int num_expert, int pool_type){
 
 
-    real dens[num_expert];
+    array[num_expert] real dens;
 
     for(i in 1:num_expert){
     if(params[i,1] == 1){
@@ -139,10 +139,10 @@ data {
   int id_trt;
   int id_comp;
 
-  int n_experts[n_time_expert];
+  array[n_time_expert] int n_experts;
   int pool_type;
 
-  real param_expert[max(n_experts),5,n_time_expert];
+  array[max(n_experts),5,n_time_expert] real param_expert;
   vector[St_indic ? n_time_expert : 0] time_expert;
 
 

--- a/inst/stan/WeibullPH_expert.stan
+++ b/inst/stan/WeibullPH_expert.stan
@@ -43,12 +43,12 @@ functions {
     return prob;
   }
 
-  real log_density_dist(real[ , ] params,
+  real log_density_dist(array[ , ] real params,
                         real x,int num_expert, int pool_type){
 
     // Evaluates the log density for a range of distributions
 
-    real dens[num_expert];
+    array[num_expert] real dens;
 
     for(i in 1:num_expert){
     if(params[i,1] == 1){
@@ -121,10 +121,10 @@ data {
   int id_trt;
   int id_comp;
 
-  int n_experts[n_time_expert];
+  array[n_time_expert] int n_experts;
   int pool_type;
 
-  real param_expert[max(n_experts),5,n_time_expert];
+  array[max(n_experts),5,n_time_expert] real param_expert;
   vector[St_indic ? n_time_expert : 0] time_expert;
 
 

--- a/inst/stan/logLogistic_expert.stan
+++ b/inst/stan/logLogistic_expert.stan
@@ -47,12 +47,12 @@ functions {
   }
 
 
-   real log_density_dist(real[ , ] params,
+   real log_density_dist(array[ , ] real params,
                         real x,int num_expert, int pool_type){
 
     // Evaluates the log density for a range of distributions
 
-    real dens[num_expert];
+    array[num_expert] real dens;
 
     for(i in 1:num_expert){
     if(params[i,1] == 1){
@@ -125,10 +125,10 @@ data {
   int id_trt;
   int id_comp;
 
-  int n_experts[n_time_expert];
+  array[n_time_expert] int n_experts;
   int pool_type;
 
-  real param_expert[max(n_experts),5,n_time_expert];
+  array[max(n_experts),5,n_time_expert] real param_expert;
   vector[St_indic ? n_time_expert : 0] time_expert;
 
 

--- a/inst/stan/logNormal_expert.stan
+++ b/inst/stan/logNormal_expert.stan
@@ -51,12 +51,12 @@ functions {
     return prob;
   }
 
-  real log_density_dist(real[ , ] params,
+  real log_density_dist(array[ , ] real params,
                         real x,int num_expert, int pool_type){
 
     // Evaluates the log density for a range of distributions
 
-    real dens[num_expert];
+    array[num_expert] real dens;
 
     for(i in 1:num_expert){
     if(params[i,1] == 1){
@@ -133,10 +133,10 @@ data {
   int id_trt;
   int id_comp;
 
-  int n_experts[n_time_expert];
+  array[n_time_expert] int n_experts;
   int pool_type;
 
-  real param_expert[max(n_experts),5,n_time_expert];
+  array[max(n_experts),5,n_time_expert] real param_expert;
   vector[St_indic ? n_time_expert : 0] time_expert;
 
 }


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
