### PR TITLE
Under-/overflows in the JAGS-models 

### DIFF
--- a/R/JAGS_Models.R
+++ b/R/JAGS_Models.R
@@ -54,7 +54,7 @@ for (i in 1:n_time_expert){
     expert_dens[j,2,i] <-  dt(St_expert[i],    param_expert[j,3,i],pow(param_expert[j,4,i],-2),max(param_expert[j,5,i],1)) 
     expert_dens[j,3,i] <-  dgamma(St_expert[i], max(param_expert[j,3,i],0.001),param_expert[j,4,i])
     expert_dens[j,4,i] <-  dlnorm(St_expert[i], param_expert[j,3,i],param_expert[j,4,i])
-    expert_dens[j,5,i] <-  dbeta(St_expert[i], max(param_expert[j,3,i], 0.01),param_expert[j,4,i])
+    expert_dens[j,5,i] <-  dbeta((s+St_expert[i]), max(param_expert[j,3,i], 0.01),param_expert[j,4,i])
     phi_temp[j,i] <- equals(pool_type,1)*(expert_dens[j,param_expert[j,1,i],i]*param_expert[j,2,i])+equals(pool_type,0)*(expert_dens[j,param_expert[j,1,i],i]^param_expert[j,2,i])
     }
  
@@ -116,7 +116,7 @@ for (i in 1:n_time_expert){
     expert_dens[j,2,i] <-  dt(St_expert[i],    param_expert[j,3,i],pow(param_expert[j,4,i],-2),max(param_expert[j,5,i],1)) 
     expert_dens[j,3,i] <-  dgamma(St_expert[i], max(param_expert[j,3,i],0.001),param_expert[j,4,i])
     expert_dens[j,4,i] <-  dlnorm(St_expert[i], param_expert[j,3,i],param_expert[j,4,i])
-    expert_dens[j,5,i] <-  dbeta(St_expert[i], max(param_expert[j,3,i], 0.01),param_expert[j,4,i])
+    expert_dens[j,5,i] <-  dbeta((s+St_expert[i]), max(param_expert[j,3,i], 0.01),param_expert[j,4,i])
     phi_temp[j,i] <- equals(pool_type,1)*(expert_dens[j,param_expert[j,1,i],i]*param_expert[j,2,i])+equals(pool_type,0)*(expert_dens[j,param_expert[j,1,i],i]^param_expert[j,2,i])
     }
  
@@ -130,6 +130,7 @@ alpha ~ dgamma(a_alpha,b_alpha);
 rate <- exp(beta[1]);
 
 C <- 10000
+s <- 0.0001
 
 }"
 GenGamma.jags <- "
@@ -180,7 +181,7 @@ for (i in 1:n_time_expert){
     expert_dens[j,2,i] <-  dt(St_expert[i],    param_expert[j,3,i],pow(param_expert[j,4,i],-2),max(param_expert[j,5,i],1)) 
     expert_dens[j,3,i] <-  dgamma(St_expert[i], max(param_expert[j,3,i],0.001),param_expert[j,4,i])
     expert_dens[j,4,i] <-  dlnorm(St_expert[i], param_expert[j,3,i],param_expert[j,4,i])
-    expert_dens[j,5,i] <-  dbeta(St_expert[i], max(param_expert[j,3,i], 0.01),param_expert[j,4,i])
+    expert_dens[j,5,i] <-  dbeta((s+St_expert[i]), max(param_expert[j,3,i], 0.01),param_expert[j,4,i])
     phi_temp[j,i] <- equals(pool_type,1)*(expert_dens[j,param_expert[j,1,i],i]*param_expert[j,2,i])+equals(pool_type,0)*(expert_dens[j,param_expert[j,1,i],i]^param_expert[j,2,i])
     }
  
@@ -193,6 +194,8 @@ r ~ dgamma(a_alpha,b_alpha);
 b ~ dgamma(a_alpha,b_alpha);
 
 C <- 10000
+s <- 0.0001
+
 sigma <- 1/(b*pow(r,0.5))
 Q <- pow(r,-0.5)
 mu <- -beta_jags[1] + (log(r)/b)


### PR DESCRIPTION
JAGS models may fail with an error in node parents. Likely an issue with under-/overflows in the JAGS-models. Adding a small positive number seems to fix the issue, so reusing parameter s.

The fix is only proposed for beta, but may be required for all distributions. I haven't checked the others, but can with my data if that's helpful.